### PR TITLE
Update form fields after SSO changes

### DIFF
--- a/shpec/oradown_shpec.sh
+++ b/shpec/oradown_shpec.sh
@@ -16,14 +16,14 @@ describe "-V, --version argument"
         assert equal "$?" "0"
     end
 
-    it "-V prints 'oradown version: 0.0.3'"
+    it "-V prints 'oradown version: 0.0.4'"
         message="$($SHPEC_ROOT/../oradown.sh -V 2>&1)"
-        assert grep "${message}" "oradown version: 0.0.3"
+        assert grep "${message}" "oradown version: 0.0.4"
     end
 
-    it "--version prints 'oradown version: 0.0.3'"
+    it "--version prints 'oradown version: 0.0.4'"
         message="$($SHPEC_ROOT/../oradown.sh --version 2>&1)"
-        assert grep "${message}" "oradown version: 0.0.3"
+        assert grep "${message}" "oradown version: 0.0.4"
     end
 end
 


### PR DESCRIPTION
Tests have been failing these past weeks due to changes in the Oracle SSO service.

The cause of these failures is the addition of a few mandatory form fields besides OAM_REQ.

I haven't tested thoroughly yet but downloading [jdk-10.0.2_linux-x64_bin.rpm](http://download.oracle.com/otn/java/jdk/10.0.2+13/19aef61b38124481863b1413dce1855f/jdk-10.0.2_linux-x64_bin.rpm) worked fine on my machine.