### PR TITLE
Remove bash dependency from shpec

### DIFF
--- a/shpec/oradown_shpec.sh
+++ b/shpec/oradown_shpec.sh
@@ -88,7 +88,7 @@ describe "URL"
     end
 end
 
-if [[ "${ORA_LOGIN}" -ne "" ]]; then
+if [ "${ORA_LOGIN}" != "" ]; then
     describe "OK input"
         it "OK input causes exits status 0"
             $SHPEC_ROOT/../oradown.sh --username=${TEST_USERNAME} --password=${TEST_PASSWORD} --cookie=${TEST_LICENSE_COOKIE} ${TEST_URL} >/dev/null 2>&1


### PR DESCRIPTION
In 5c49eb4 I added an if [[ ]] check;  this is good practice with bash
but breaks with the dash that Ubuntu (and thus Travis) use by default.
The result is that the remote checks never run, even is ORA_LOGIN is
set: https://travis-ci.org/typekpb/oradown/builds/547074553

Changing to single square brackets [ ] that should work with all POSIX
shells.